### PR TITLE
Added tokenization capability for accented languages

### DIFF
--- a/src/Camspiers/StatisticalClassifier/Tokenizer/Word.php
+++ b/src/Camspiers/StatisticalClassifier/Tokenizer/Word.php
@@ -22,9 +22,6 @@ class Word implements TokenizerInterface
      */
     public function tokenize($document)
     {
-        $matches = array();
-        preg_match_all("/[\w]+/", $document, $matches, PREG_PATTERN_ORDER);
-
-        return isset($matches[0]) ? $matches[0] : array();
+        return preg_split('/\PL+/u', $document, null, PREG_SPLIT_NO_EMPTY);
     }
 }

--- a/tests/Camspiers/StatisticalClassifier/Tokenizer/WordTest.php
+++ b/tests/Camspiers/StatisticalClassifier/Tokenizer/WordTest.php
@@ -25,10 +25,11 @@ class WordTest extends \PHPUnit_Framework_TestCase
             array(
                 'this',
                 'is',
-                'a'
+                'a',
+                'français',
             ),
             $this->word->tokenize(
-                'this is a'
+                'this is a "français"'
             )
         );
     }


### PR DESCRIPTION
This little change allows the current tokenizer to tokenize accented languages as french. Plus preg_split should be way faster than preg_match_all for the tokenization purpose.
